### PR TITLE
:sparkles: Support Rank URL

### DIFF
--- a/Playgrounds/Scrubber/Scrubber/Backend/ViewModel.swift
+++ b/Playgrounds/Scrubber/Scrubber/Backend/ViewModel.swift
@@ -29,7 +29,7 @@ class ViewModel: ObservableObject, Identifiable {
         } else {
             core = .init(query: query)
         }
-        
+
         core.run { document in
             self.documents = document
             self.saveToDownloads()

--- a/Playgrounds/Scrubber/Scrubber/Backend/ViewModel.swift
+++ b/Playgrounds/Scrubber/Scrubber/Backend/ViewModel.swift
@@ -11,8 +11,25 @@ import ScrubberKit
 class ViewModel: ObservableObject, Identifiable {
     let id: UUID = .init()
 
-    init(query: String) {
-        core = .init(query: query)
+    init(
+        query: String,
+        enableURLsReranker: Bool = false,
+        enableBM5Reranker: Bool = false,
+        keepKPerHostname: Int? = nil
+    ) {
+        if enableURLsReranker {
+            let urlsReranker = URLsReranker(
+                question: enableBM5Reranker ? query : nil,
+                keepKPerHostname: keepKPerHostname
+            )
+            core = .init(
+                query: query,
+                options: .init(urlsReranker: urlsReranker)
+            )
+        } else {
+            core = .init(query: query)
+        }
+        
         core.run { document in
             self.documents = document
             self.saveToDownloads()

--- a/Playgrounds/Scrubber/Scrubber/Interface/ContentView.swift
+++ b/Playgrounds/Scrubber/Scrubber/Interface/ContentView.swift
@@ -41,8 +41,8 @@ struct ContentView: View {
             .buttonStyle(.plain)
             .underline()
             .disabled(searchQuery.isEmpty)
-            
-            HStack{
+
+            HStack {
                 Toggle("URLs Reranker", isOn: $enableURLsReranker)
                     .toggleStyle(.switch)
                 if enableURLsReranker {
@@ -59,7 +59,7 @@ struct ContentView: View {
                     }, set: {
                         keepKPerHostname = $0 == 0 ? nil : Int($0)
                     }),
-                    in: 0...10,
+                    in: 0 ... 10,
                     step: 1,
                     minimumValueLabel: Text("0"),
                     maximumValueLabel: Text("10"),

--- a/Playgrounds/Scrubber/Scrubber/Interface/ContentView.swift
+++ b/Playgrounds/Scrubber/Scrubber/Interface/ContentView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct ContentView: View {
     @State var searchQuery: String = ""
+    @State var enableURLsReranker: Bool = false
+    @State var enableBM5Reranker: Bool = true
+    @State var keepKPerHostname: Int? = 4
     @State var vm: ViewModel? = nil
 
     var body: some View {
@@ -38,6 +41,34 @@ struct ContentView: View {
             .buttonStyle(.plain)
             .underline()
             .disabled(searchQuery.isEmpty)
+            
+            HStack{
+                Toggle("URLs Reranker", isOn: $enableURLsReranker)
+                    .toggleStyle(.switch)
+                if enableURLsReranker {
+                    Toggle("BM5 Reranker", isOn: $enableBM5Reranker)
+                        .toggleStyle(.switch)
+                }
+                Spacer()
+            }
+            .frame(maxWidth: 500)
+            if enableURLsReranker {
+                Slider(
+                    value: Binding(get: {
+                        Double(keepKPerHostname ?? 0)
+                    }, set: {
+                        keepKPerHostname = $0 == 0 ? nil : Int($0)
+                    }),
+                    in: 0...10,
+                    step: 1,
+                    minimumValueLabel: Text("0"),
+                    maximumValueLabel: Text("10"),
+                    label: {
+                        Text("Keep Top \(keepKPerHostname ?? 0) Per Hostname")
+                    }
+                )
+                .frame(maxWidth: 500)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -46,7 +77,12 @@ struct ContentView: View {
         let query = searchQuery
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return }
-        vm = ViewModel(query: query)
+        vm = ViewModel(
+            query: query,
+            enableURLsReranker: enableURLsReranker,
+            enableBM5Reranker: enableBM5Reranker,
+            keepKPerHostname: keepKPerHostname
+        )
     }
 }
 

--- a/Sources/ScrubberKit/Algorithms/BM25Okapi.swift
+++ b/Sources/ScrubberKit/Algorithms/BM25Okapi.swift
@@ -47,7 +47,7 @@ class BM25Okapi {
         totalDocs = documents.count
         averageDocLength =
             docLengths.isEmpty
-            ? 0 : Double(docLengths.reduce(0, +)) / Double(docLengths.count)
+                ? 0 : Double(docLengths.reduce(0, +)) / Double(docLengths.count)
     }
 
     func search(query: String) -> [(index: Int, score: Double)] {
@@ -91,7 +91,7 @@ class BM25Okapi {
         let tokenizer = NLTokenizer(unit: .word)
         tokenizer.string = text
         var keyWords: [String] = []
-        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) {
+        tokenizer.enumerateTokens(in: text.startIndex ..< text.endIndex) {
             tokenRange, _ in
             keyWords.append(String(text[tokenRange]))
             return true
@@ -101,11 +101,11 @@ class BM25Okapi {
 
     func normalize(scores: [(index: Int, score: Double)]) -> [Int: Double] {
         let sumScores = scores.reduce(0.0) { $0 + $1.score }
-        
+
         if sumScores == 0 {
             return Dictionary(uniqueKeysWithValues: scores.map { ($0.index, 0.0) })
         }
-        
+
         return Dictionary(uniqueKeysWithValues: scores.map { ($0.index, $0.score / sumScores) })
     }
 }

--- a/Sources/ScrubberKit/Algorithms/BM25Okapi.swift
+++ b/Sources/ScrubberKit/Algorithms/BM25Okapi.swift
@@ -1,0 +1,111 @@
+//
+//  BM25Okapi.swift
+//  ScrubberKit
+//
+//  Created by John Mai on 2025/3/15.
+//
+
+import Foundation
+import NaturalLanguage
+
+class BM25Okapi {
+    private let k1: Double
+    private let b: Double
+
+    private var corpus: [[String]] = []
+    private var docFrequency: [String: Int] = [:]
+    private var docLengths: [Int] = []
+    private var averageDocLength: Double = 0
+    private var totalDocs: Int = 0
+
+    init(k1: Double = 1.5, b: Double = 0.75) {
+        self.k1 = k1
+        self.b = b
+    }
+
+    func fit(_ documents: [String]) {
+        corpus = []
+        docFrequency = [:]
+        docLengths = []
+
+        for document in documents {
+            let tokens = tokenize(document)
+            corpus.append(tokens)
+
+            let docLength = tokens.count
+            docLengths.append(docLength)
+
+            var seenTokens = Set<String>()
+            for token in tokens {
+                if !seenTokens.contains(token) {
+                    docFrequency[token, default: 0] += 1
+                    seenTokens.insert(token)
+                }
+            }
+        }
+
+        totalDocs = documents.count
+        averageDocLength =
+            docLengths.isEmpty
+            ? 0 : Double(docLengths.reduce(0, +)) / Double(docLengths.count)
+    }
+
+    func search(query: String) -> [(index: Int, score: Double)] {
+        let queryTokens = tokenize(query)
+        var scores: [Double] = Array(repeating: 0, count: corpus.count)
+
+        for (docIndex, document) in corpus.enumerated() {
+            var score: Double = 0
+
+            for token in queryTokens {
+                guard let df = docFrequency[token], df > 0 else { continue }
+
+                let idf = calculateIDF(token: token)
+
+                let tf = document.filter { $0 == token }.count
+
+                let docLength = Double(docLengths[docIndex])
+                let numerator = Double(tf) * (k1 + 1)
+                let denominator =
+                    Double(tf) + k1 * (1 - b + b * docLength / averageDocLength)
+                let termScore = idf * numerator / denominator
+
+                score += termScore
+            }
+
+            scores[docIndex] = score
+        }
+
+        return scores.enumerated()
+            .map { (index: $0, score: $1) }
+            .sorted { $0.score > $1.score }
+    }
+
+    func calculateIDF(token: String) -> Double {
+        let n = docFrequency[token] ?? 0
+        return log(
+            (Double(totalDocs) - Double(n) + 0.5) / (Double(n) + 0.5) + 1)
+    }
+
+    func tokenize(_ text: String) -> [String] {
+        let tokenizer = NLTokenizer(unit: .word)
+        tokenizer.string = text
+        var keyWords: [String] = []
+        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) {
+            tokenRange, _ in
+            keyWords.append(String(text[tokenRange]))
+            return true
+        }
+        return keyWords
+    }
+
+    func normalize(scores: [(index: Int, score: Double)]) -> [Int: Double] {
+        let sumScores = scores.reduce(0.0) { $0 + $1.score }
+        
+        if sumScores == 0 {
+            return Dictionary(uniqueKeysWithValues: scores.map { ($0.index, 0.0) })
+        }
+        
+        return Dictionary(uniqueKeysWithValues: scores.map { ($0.index, $0.score / sumScores) })
+    }
+}

--- a/Sources/ScrubberKit/Scrubber+Options.swift
+++ b/Sources/ScrubberKit/Scrubber+Options.swift
@@ -1,0 +1,16 @@
+//
+//  Scrubber+Options.swift
+//  ScrubberKit
+//
+//  Created by John Mai on 2025/3/15.
+//
+
+extension Scrubber {
+    public struct ScrubberOptions {
+        let urlsReranker: URLsReranker?
+        
+        public init(urlsReranker: URLsReranker? = nil) {
+            self.urlsReranker = urlsReranker
+        }
+    }
+}

--- a/Sources/ScrubberKit/Scrubber+Options.swift
+++ b/Sources/ScrubberKit/Scrubber+Options.swift
@@ -5,10 +5,10 @@
 //  Created by John Mai on 2025/3/15.
 //
 
-extension Scrubber {
-    public struct ScrubberOptions {
+public extension Scrubber {
+    struct ScrubberOptions {
         let urlsReranker: URLsReranker?
-        
+
         public init(urlsReranker: URLsReranker? = nil) {
             self.urlsReranker = urlsReranker
         }

--- a/Sources/ScrubberKit/Scrubber.swift
+++ b/Sources/ScrubberKit/Scrubber.swift
@@ -10,8 +10,12 @@ import Foundation
 
 public class Scrubber {
     public let query: String
+    public let options: ScrubberOptions
 
-    public init(query: String) { self.query = query }
+    public init(query: String, options: ScrubberOptions = .init()) {
+        self.query = query
+        self.options = options
+    }
 
     private(set) var isCancelled: Bool = false
     private var cores: [UUID: ScrubWorker] = [:]
@@ -38,15 +42,23 @@ public class Scrubber {
         onProgress: @escaping (Progress) -> Void = { _ in }
     ) {
         assert(Thread.isMainThread)
+        
         var cancellables: Set<AnyCancellable> = .init()
+        let limitation = limitation ?? 20
+        
         progress.updatePublisher
             .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] progress in
                 onProgress(progress)
-                self?.cancelIf(limitation: limitation ?? 20, lastTenPercent: true)
+                self?.cancelIf(limitation: limitation, lastTenPercent: true)
             }
             .store(in: &cancellables)
-        search()
+        
+        if let urlsReranker = options.urlsReranker {
+            search(urlsReranker, topN: limitation)
+        } else {
+            search()
+        }
 
         DispatchQueue.global().async {
             _ = self.dispatchGroup.wait(timeout: .now() + 45)
@@ -209,6 +221,68 @@ public extension Scrubber {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 20) {
             completion(nil)
+        }
+    }
+}
+
+extension Scrubber {
+    private func search(_ reranker: URLsReranker, topN: Int) {
+        assert(Thread.isMainThread)
+        let searchGroup = DispatchGroup()
+        var searchSnippets: [SearchSnippet] = []
+
+        for engine in ScrubEngine.allCases {
+            self.progress.update(engine: engine, status: .fetching)
+            guard let query = engine.makeSearchQueryRequest(self.query)
+            else {
+                self.progress.update(
+                    engine: engine, status: .completed(result: 0))
+                continue
+            }
+
+            searchGroup.enterBackground { leaver in
+                self.scrub(url: query, retry: 2) { result in
+                    let snippets = engine.parseSearchSnippet(
+                        result?.document ?? "")
+                    searchSnippets.append(contentsOf: snippets)
+                    leaver()
+                }
+            }
+        }
+
+        self.dispatchGroup.enterBackground { leaver in
+            searchGroup.wait()
+
+            let snippets = reranker.ranking(searchSnippets)
+
+            let groupedSnippets = Dictionary(
+                grouping: snippets.prefix(topN),
+                by: { $0.engine }
+            )
+
+            for (engine, snippets) in groupedSnippets {
+                self.dispatchGroup.enterBackground { leaver in
+
+                    let searchResults = snippets.map(\.url)
+
+                    self.progress.update(
+                        engine: engine,
+                        status: .completed(result: searchResults.count)
+                    )
+
+                    DispatchQueue.main.async {
+                        self.process(candidates: searchResults, engine: engine)
+                        leaver()
+                    }
+                }
+            }
+            
+            let missingEngines = Set(ScrubEngine.allCases).subtracting(groupedSnippets.keys)
+            for engine in missingEngines {
+                self.progress.update(engine: engine, status: .completed(result: 0))
+            }
+            
+            leaver()
         }
     }
 }

--- a/Sources/ScrubberKit/Supplements/ScrubEngine.swift
+++ b/Sources/ScrubberKit/Supplements/ScrubEngine.swift
@@ -137,4 +137,202 @@ public enum ScrubEngine: String, CaseIterable, Codable {
 
         return possibleURLs
     }
+    
+    private func parse(body: Element) -> [SearchSnippet] {
+        assert(!Thread.isMainThread)
+
+        var snippets: [SearchSnippet] = []
+        switch self {
+        case .google:
+            try? body.select("#rso").forEach { object in
+                
+                let elements = object.children()
+                
+                for element in elements {
+                    let link = extractLink(
+                        try? element.select("[href]").array().first
+                    )
+
+                    guard let link else {
+                        return
+                    }
+
+                    let title = try? element.select("h3").first()?.text()
+
+                    let description = try?
+                        (element.select("div.VwiC3b").first()
+                        ?? element.select("span.st").first())?.text()
+
+                    snippets.append(
+                        .init(
+                            engine: self,
+                            url: link,
+                            title: title,
+                            description: description
+                        )
+                    )
+                }
+                    
+                
+                
+            }
+        case .duckduckgo:
+            try? body.select(".react-results--main").forEach { object in
+                object.children().forEach { listElement in
+                    let link = extractLink(
+                        try? listElement.select(
+                            "[data-testid=result-title-a]"
+                        ).first
+                    )
+
+                    guard let link else {
+                        return
+                    }
+
+                    let title = try? listElement.select(
+                        "[data-testid=result-title-a] span"
+                    ).first()?.text()
+
+                    let description = try? listElement.select(
+                        "[data-result=snippet"
+                    ).first()?.text()
+
+                    snippets.append(
+                        .init(
+                            engine: self,
+                            url: link,
+                            title: title,
+                            description: description
+                        )
+                    )
+                }
+            }
+        case .yahoo:
+            try? body.select("#main-algo").forEach { object in
+                try? object.select("section.algo").forEach({ section in
+                    let link = extractLink(
+                        try? section.select(".title [href]").array().first
+                    )
+
+                    guard let link else {
+                        return
+                    }
+
+                    let title = try? section.select(".title a.s-title").first()?
+                        .text()
+
+                    let description = try? section.select("p.s-desc").first()?
+                        .text()
+
+                    snippets.append(
+                        .init(
+                            engine: self,
+                            url: link,
+                            title: title,
+                            description: description
+                        )
+                    )
+                })
+            }
+        case .bing:
+            try? body.select("ol#b_results li.b_algo").forEach { algo in
+                let link = extractLink(
+                    try? algo.select("div.b_algoheader a[href]").first()
+                )
+
+                guard let link else {
+                    return
+                }
+
+                let title = try? algo.select("div.b_algoheader a h2").first()?
+                    .text()
+
+                let description = try? algo.select(".b_caption p").first()?
+                    .text()
+
+                snippets.append(
+                    .init(
+                        engine: self,
+                        url: link,
+                        title: title,
+                        description: description
+                    )
+                )
+            }
+        }
+
+        return snippets
+    }
+    
+    private func extractLink(_ element: Element?) -> URL? {
+        guard let linkText = try? element?.attr("href") else {
+            return nil
+        }
+
+        let link = linkText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard
+            !link.isEmpty && !link.starts(with: "/") && !link.starts(with: "#")
+        else {
+            return nil
+        }
+
+        let url = URL(string: link)
+
+        guard url?.scheme == "http" || url?.scheme == "https" else {
+            return nil
+        }
+
+        guard url?.host?.isEmpty == false else {
+            return nil
+        }
+
+        return url
+    }
+    
+    func parseSearchSnippet(_ html: String) -> [SearchSnippet] {
+        assert(!Thread.isMainThread)
+        
+        guard let soup = try? SwiftSoup.parse(html) else { return [] }
+        guard let body = soup.body() else { return [] }
+
+        var snippets: [SearchSnippet] = parse(body: body)
+        if snippets.isEmpty {
+            try? body.select("a[href]").array().forEach { element in
+
+                let link = extractLink(element)
+
+                guard let link else {
+                    return
+                }
+
+                let title = try? element.text()
+
+                snippets.append(
+                    .init(
+                        engine: self,
+                        url: link,
+                        title: title
+                    )
+                )
+            }
+        }
+
+        let searchContent = snippets.map { $0.url.absoluteString }
+
+        snippets = snippets.filter { snippet in
+            !searchContent.contains { match in
+                snippet.url.absoluteString.contains(match)
+                    && snippet.url.absoluteString != match
+            }
+        }.filter { snippet in
+            !snippets.contains { match in
+                snippet.url.absoluteString.lowercased()
+                    == match.url.absoluteString.lowercased()
+                    && snippet.url.absoluteString != match.url.absoluteString
+            }
+        }
+
+        return snippets
+    }
 }

--- a/Sources/ScrubberKit/Supplements/ScrubEngine.swift
+++ b/Sources/ScrubberKit/Supplements/ScrubEngine.swift
@@ -137,7 +137,7 @@ public enum ScrubEngine: String, CaseIterable, Codable {
 
         return possibleURLs
     }
-    
+
     private func parse(body: Element) -> [SearchSnippet] {
         assert(!Thread.isMainThread)
 
@@ -145,9 +145,9 @@ public enum ScrubEngine: String, CaseIterable, Codable {
         switch self {
         case .google:
             try? body.select("#rso").forEach { object in
-                
+
                 let elements = object.children()
-                
+
                 for element in elements {
                     let link = extractLink(
                         try? element.select("[href]").array().first
@@ -161,7 +161,7 @@ public enum ScrubEngine: String, CaseIterable, Codable {
 
                     let description = try?
                         (element.select("div.VwiC3b").first()
-                        ?? element.select("span.st").first())?.text()
+                            ?? element.select("span.st").first())?.text()
 
                     snippets.append(
                         .init(
@@ -172,13 +172,10 @@ public enum ScrubEngine: String, CaseIterable, Codable {
                         )
                     )
                 }
-                    
-                
-                
             }
         case .duckduckgo:
             try? body.select(".react-results--main").forEach { object in
-                object.children().forEach { listElement in
+                for listElement in object.children() {
                     let link = extractLink(
                         try? listElement.select(
                             "[data-testid=result-title-a]"
@@ -186,7 +183,7 @@ public enum ScrubEngine: String, CaseIterable, Codable {
                     )
 
                     guard let link else {
-                        return
+                        continue
                     }
 
                     let title = try? listElement.select(
@@ -209,7 +206,7 @@ public enum ScrubEngine: String, CaseIterable, Codable {
             }
         case .yahoo:
             try? body.select("#main-algo").forEach { object in
-                try? object.select("section.algo").forEach({ section in
+                try? object.select("section.algo").forEach { section in
                     let link = extractLink(
                         try? section.select(".title [href]").array().first
                     )
@@ -232,7 +229,7 @@ public enum ScrubEngine: String, CaseIterable, Codable {
                             description: description
                         )
                     )
-                })
+                }
             }
         case .bing:
             try? body.select("ol#b_results li.b_algo").forEach { algo in
@@ -263,7 +260,7 @@ public enum ScrubEngine: String, CaseIterable, Codable {
 
         return snippets
     }
-    
+
     private func extractLink(_ element: Element?) -> URL? {
         guard let linkText = try? element?.attr("href") else {
             return nil
@@ -289,10 +286,10 @@ public enum ScrubEngine: String, CaseIterable, Codable {
 
         return url
     }
-    
+
     func parseSearchSnippet(_ html: String) -> [SearchSnippet] {
         assert(!Thread.isMainThread)
-        
+
         guard let soup = try? SwiftSoup.parse(html) else { return [] }
         guard let body = soup.body() else { return [] }
 

--- a/Sources/ScrubberKit/Supplements/URLsReranker.swift
+++ b/Sources/ScrubberKit/Supplements/URLsReranker.swift
@@ -1,0 +1,306 @@
+//
+//  URLsReranker.swift
+//  ScrubberKit
+//
+//  Created by John Mai on 2025/3/14.
+//
+
+import Foundation
+
+public final class URLsReranker {
+
+    let freqFactor: Double
+    let hostnameBoostFactor: Double
+    let pathBoostFactor: Double
+    let decayFactor: Double
+    let bm25RerankFactor: Double
+    let minBoost: Double
+    let maxBoost: Double
+    let question: String?
+    let keepKPerHostname: Int?
+
+    public init(
+        freqFactor: Double = 0.5,
+        hostnameBoostFactor: Double = 0.5,
+        pathBoostFactor: Double = 0.4,
+        decayFactor: Double = 0.8,
+        bm25RerankFactor: Double = 0.8,
+        minBoost: Double = 0,
+        maxBoost: Double = 5,
+        question: String? = nil,
+        keepKPerHostname: Int? = nil
+    ) {
+        self.freqFactor = freqFactor
+        self.hostnameBoostFactor = hostnameBoostFactor
+        self.pathBoostFactor = pathBoostFactor
+        self.decayFactor = decayFactor
+        self.bm25RerankFactor = bm25RerankFactor
+        self.minBoost = minBoost
+        self.maxBoost = maxBoost
+        self.question = question
+        self.keepKPerHostname = keepKPerHostname
+    }
+
+    private func normalizeCount(_ count: Double, _ total: Double) -> Double {
+        return total > 0 ? count / total : 0
+    }
+
+    private func extractUrlParts(_ url: URL) -> (
+        hostname: String, path: String
+    ) {
+        return (hostname: url.host ?? "", path: url.path)
+    }
+
+    private func countUrlParts(urls: [URL]) -> (
+        hostnameCount: [String: Int],
+        pathPrefixCount: [String: Int],
+        totalUrls: Double
+    ) {
+        var hostnameCount: [String: Int] = [:]
+        var pathPrefixCount: [String: Int] = [:]
+        var totalUrls = 0
+
+        for item in urls {
+            totalUrls += 1
+            let hostname = item.host ?? ""
+            let path = item.path
+
+            hostnameCount[hostname] =
+                (hostnameCount[hostname] ?? 0) + 1
+
+            let pathSegments = path.split(separator: "/").filter {
+                !$0.isEmpty
+            }.map { String($0) }
+            for (index, _) in pathSegments.enumerated() {
+                let prefix =
+                    "/" + pathSegments[0...index].joined(separator: "/")
+                pathPrefixCount[prefix] = (pathPrefixCount[prefix] ?? 0) + 1
+            }
+        }
+
+        return (hostnameCount, pathPrefixCount, Double(totalUrls))
+    }
+
+    private func smartMergeStrings(str1: String?, str2: String?) -> String {
+        guard let str1 else { return str2 ?? "" }
+        guard let str2 else { return str1 }
+
+        if str1.contains(str2) { return str1 }
+        if str2.contains(str1) { return str2 }
+
+        let maxOverlap = min(str1.count, str2.count)
+        var bestOverlapLength = 0
+
+        var overlapLength = maxOverlap
+        while overlapLength > 0 {
+            let endOfStr1 = str1.suffix(overlapLength)
+            let startOfStr2 = str2.prefix(overlapLength)
+
+            if endOfStr1 == startOfStr2 {
+                bestOverlapLength = overlapLength
+                break
+            }
+            overlapLength -= 1
+        }
+
+        if bestOverlapLength > 0 {
+            let newStr = str1.prefix(str1.count - bestOverlapLength) + str2
+            return String(newStr)
+        } else {
+            return str1 + str2
+        }
+    }
+
+    public func ranking(_ snippets: [SearchSnippet]) -> [BoostedSearchSnippet] {
+        let urls = snippets.compactMap { $0.url }
+        guard !urls.isEmpty else { return [] }
+
+        let (hostnameCount, pathPrefixCount, totalUrls) = countUrlParts(
+            urls: urls)
+        
+        var bm25Scores: [String: Double] = [:]
+        if let question = self.question {
+            let bm25 = BM25Okapi()
+            let documents = snippets.map {
+                smartMergeStrings(str1: $0.title, str2: $0.description)
+            }
+            bm25.fit(documents)
+            let results = bm25.search(query: question)
+            let normalized = bm25.normalize(scores: results)
+            
+            for (i, snippet) in snippets.enumerated() {
+                bm25Scores[snippet.url.absoluteString] = normalized[i]
+            }
+        }
+
+        var boostedSnippets: [BoostedSearchSnippet] = snippets.map { snippet in
+            let hostname = snippet.url.host ?? ""
+            let path = snippet.url.path
+
+            let hostnameFreq = normalizeCount(
+                Double(hostnameCount[hostname] ?? 0), totalUrls)
+
+            let hostnameBoost = hostnameFreq * self.hostnameBoostFactor
+
+            let pathBoost = calculatePathBoost(
+                path: path, pathPrefixCount: pathPrefixCount,
+                totalUrls: totalUrls)
+
+            let freqBoost =
+                (snippet.weight ?? 0) / totalUrls * self.freqFactor
+            
+            let bm25RerankBoost = bm25Scores[snippet.url.absoluteString] ?? 0
+
+            let finalScore = min(
+                max(hostnameBoost + pathBoost + freqBoost + bm25RerankBoost, self.minBoost),
+                self.maxBoost)
+
+            return BoostedSearchSnippet(
+                from: snippet,
+                freqBoost: freqBoost,
+                hostnameBoost: hostnameBoost,
+                pathBoost: pathBoost,
+                bm25RerankBoost: bm25RerankBoost,
+                finalScore: finalScore
+            )
+        }
+
+        boostedSnippets = boostedSnippets.sorted {
+            $0.finalScore > $1.finalScore
+        }
+
+        if let keepKPerHostname = self.keepKPerHostname {
+            boostedSnippets = filterByHostname(
+                snippets: boostedSnippets, keepKPerHostname: keepKPerHostname)
+        }
+
+        return boostedSnippets
+    }
+
+    private func filterByHostname(
+        snippets: [BoostedSearchSnippet], keepKPerHostname: Int
+    ) -> [BoostedSearchSnippet] {
+        var result = [BoostedSearchSnippet]()
+        var hostnameCounter = [String: Int]()
+
+        let sortedSnippets = snippets.sorted { $0.finalScore > $1.finalScore }
+
+        for snippet in sortedSnippets {
+            let hostname = snippet.url.host ?? ""
+            if (hostnameCounter[hostname] ?? 0) < keepKPerHostname {
+                result.append(snippet)
+                hostnameCounter[hostname, default: 0] += 1
+            }
+        }
+
+        return result
+    }
+
+    private func calculatePathBoost(
+        path: String, pathPrefixCount: [String: Int], totalUrls: Double
+    ) -> Double {
+        let pathSegments = path.split(separator: "/").filter { !$0.isEmpty }
+            .map(String.init)
+        var totalBoost = 0.0
+
+        for i in 0..<pathSegments.count {
+            let prefix = "/" + pathSegments[0...i].joined(separator: "/")
+            let prefixFreq = Double(pathPrefixCount[prefix] ?? 0) / totalUrls
+            let decayedBoost =
+                prefixFreq * pow(self.decayFactor, Double(i))
+                * self.pathBoostFactor
+            totalBoost += decayedBoost
+        }
+
+        return totalBoost
+    }
+}
+
+public struct SearchSnippet {
+    public let engine: ScrubEngine
+    public let url: URL
+    public let title: String?
+    public let description: String?
+    public let weight: Double?
+
+    public init(
+        engine: ScrubEngine,
+        url: URL,
+        title: String?,
+        description: String? = nil,
+        weight: Double? = nil
+    ) {
+        self.engine = engine
+        self.url = url
+        self.title = title
+        self.description = description
+        self.weight = weight
+    }
+}
+
+public struct BoostedSearchSnippet: Equatable {
+    public let engine: ScrubEngine
+    public let url: URL
+    public let title: String?
+    public let description: String?
+    public let weight: Double?
+    public let freqBoost: Double
+    public let hostnameBoost: Double
+    public let pathBoost: Double
+    public let bm25RerankBoost: Double
+    public let finalScore: Double
+
+    public init(
+        from snippet: SearchSnippet,
+        freqBoost: Double,
+        hostnameBoost: Double,
+        pathBoost: Double,
+        bm25RerankBoost: Double = 0,
+        finalScore: Double
+    ) {
+        self.engine = snippet.engine
+        self.url = snippet.url
+        self.title = snippet.title
+        self.description = snippet.description
+        self.weight = snippet.weight
+        self.freqBoost = freqBoost
+        self.hostnameBoost = hostnameBoost
+        self.pathBoost = pathBoost
+        self.bm25RerankBoost = bm25RerankBoost
+        self.finalScore = finalScore
+    }
+}
+
+public struct RankOptions {
+    let freqFactor: Double
+    let hostnameBoostFactor: Double
+    let pathBoostFactor: Double
+    let decayFactor: Double
+    let bm25RerankFactor: Double
+    let minBoost: Double
+    let maxBoost: Double
+    let question: String?
+    let keepKPerHostname: Int?
+
+    public init(
+        freqFactor: Double = 0.5,
+        hostnameBoostFactor: Double = 0.5,
+        pathBoostFactor: Double = 0.4,
+        decayFactor: Double = 0.8,
+        bm25RerankFactor: Double = 0.8,
+        minBoost: Double = 0,
+        maxBoost: Double = 5,
+        question: String? = nil,
+        keepKPerHostname: Int? = nil
+    ) {
+        self.freqFactor = freqFactor
+        self.hostnameBoostFactor = hostnameBoostFactor
+        self.pathBoostFactor = pathBoostFactor
+        self.decayFactor = decayFactor
+        self.bm25RerankFactor = bm25RerankFactor
+        self.minBoost = minBoost
+        self.maxBoost = maxBoost
+        self.question = question
+        self.keepKPerHostname = keepKPerHostname
+    }
+}


### PR DESCRIPTION
# Support Rank URL

> From Jina AI: [Snippet Selection and URL Ranking in DeepSearch/DeepResearch](https://jina.ai/news/snippet-selection-and-url-ranking-in-deepsearch-deepresearch/#rank-url-for-next-read)

![image](https://github.com/user-attachments/assets/b6cbd5ca-51bb-4e71-8c06-14ced610a9f9)

## Features
- Save context-length
- Filter out meaningless documents

## Difference
Semantic Relevance: Instead of using the Jina reranker model, directly switch to reordering with BM25 scores, perform relative normalization on the scores, and then calculate the bm25RerankFactor.

## Result
<img width="677" alt="image" src="https://github.com/user-attachments/assets/df98298b-9e2e-4542-bffc-7887de6ede3a" />


