### PR TITLE
fix: disabled engine functionality

### DIFF
--- a/Sources/ScrubberKit/Scrubber.swift
+++ b/Sources/ScrubberKit/Scrubber.swift
@@ -101,7 +101,7 @@ public class Scrubber {
 
     private func search() {
         assert(Thread.isMainThread)
-        for engine in ScrubEngine.allCases {
+        for engine in enabledEngines {
             progress.update(engine: engine, status: .fetching)
             guard let query = engine.makeSearchQueryRequest(query) else {
                 progress.update(engine: engine, status: .completed(result: 0))
@@ -237,7 +237,7 @@ extension Scrubber {
         let searchGroup = DispatchGroup()
         var searchSnippets: [SearchSnippet] = []
 
-        for engine in ScrubEngine.allCases {
+        for engine in enabledEngines {
             progress.update(engine: engine, status: .fetching)
             guard let query = engine.makeSearchQueryRequest(query)
             else {
@@ -283,12 +283,21 @@ extension Scrubber {
                 }
             }
 
-            let missingEngines = Set(ScrubEngine.allCases).subtracting(groupedSnippets.keys)
+            let missingEngines = Set(self.enabledEngines).subtracting(groupedSnippets.keys)
             for engine in missingEngines {
                 self.progress.update(engine: engine, status: .completed(result: 0))
             }
 
             leaver()
+        }
+    }
+}
+
+fileprivate extension Scrubber {
+    var enabledEngines: [ScrubEngine] {
+        let disabledEngines = ScrubberConfiguration.disabledEngines
+        return ScrubEngine.allCases.filter { engine in
+            !disabledEngines.contains(engine)
         }
     }
 }


### PR DESCRIPTION
在 FlowDown 修一个 bug 的时候发现我把 Yahoo 关了还是会在 websearch 工具内出现 Yahoo 的结果（而 Yahoo 恰好中国大陆无服务，因此那个结果占在搜索条目里很扎眼）
然后发现设置里把 Yahoo 关了仍然出现，新建 Chat 也于事无补，一路找代码发现这个问题（）

![CleanShot 2025-12-02 at 8  16 26@2x](https://github.com/user-attachments/assets/88822607-83cd-4911-9560-457cfd90dda6)
![CleanShot 2025-12-02 at 8  17 14@2x](https://github.com/user-attachments/assets/6cee79c1-da47-4e27-9484-8e6210b512b0)
